### PR TITLE
Added NamedTemporaryFile approach with Windows-support

### DIFF
--- a/hypermax/algorithms/atpe_optimizer.py
+++ b/hypermax/algorithms/atpe_optimizer.py
@@ -6,13 +6,13 @@ import numpy
 import numpy.random
 import json
 import pkg_resources
-import tempfile
 from hypermax.hyperparameter import Hyperparameter
 import sklearn
 import lightgbm
 import scipy.stats
 import math
 import copy
+import hypermax.file_utils
 
 class ATPEOptimizer(OptimizationAlgorithmBase):
     atpeParameters = [
@@ -182,9 +182,8 @@ class ATPEOptimizer(OptimizationAlgorithmBase):
         self.parameterModelConfigurations = {}
         for param in self.atpeParameters:
             modelData = pkg_resources.resource_string(__name__, "../atpe_models/model-" + param + '.txt')
-            with tempfile.NamedTemporaryFile() as file:
-                file.write(modelData)
-                self.parameterModels[param] = lightgbm.Booster(model_file=file.name)
+            with hypermax.file_utils.ClosedNamedTempFile(modelData) as model_file_name:
+                self.parameterModels[param] = lightgbm.Booster(model_file=model_file_name)
 
             configString = pkg_resources.resource_string(__name__, "../atpe_models/model-" + param + '-configuration.json')
             data = json.loads(configString)

--- a/hypermax/file_utils.py
+++ b/hypermax/file_utils.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+import tempfile
+import os
+
+# Windows doesn't support opening a NamedTemporaryFile.
+# Solution inspired in https://stackoverflow.com/a/46501017/147507
+@contextmanager
+def ClosedNamedTempFile(contents):
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            file_name = f.name
+            f.write(contents)
+        yield file_name
+    finally:
+        os.unlink(file_name)


### PR DESCRIPTION
Hi! I've been trying to use HyperMax in Windows and found a couple of issues. Hence, you'll see a few PRs from me hoping to help make this product a little better.

In this case, the PR is about the usage of `NamedTemporaryFile()` for passing along the model data to lightgbm, which in turn reads from that file.

Turns out that Windows doesn't like that very much, and as per [Python docs](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile):

> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later).

This all means that lightgbm was not able to read from the file and crashed the tool.

This approach basically allows the file to be closed (but not deleted) and deletes it after the `with` scope is done.

I also moved it into a `file_utils` module to avoid clogging the `atpe_optimizer` class more, since it's big enough already. This will help when tests are written for all modules.

Final disclaimer: I've been able to test this in Windows, but I only _believe_ it should work in Linux/MacOS. I don't have a platform to test it in right now, but I'd appreciate some help with that.