### PR TITLE
Fix crash when results.csv does not exist

### DIFF
--- a/hypermax/cli.py
+++ b/hypermax/cli.py
@@ -21,9 +21,14 @@ def main():
     optimizer = Optimizer(config_data)
 
     if args.results_directory:
-        optimizer.importResultsCSV(os.path.join(args.results_directory, 'results.csv'))
-        if os.path.exists(os.path.join(args.results_directory, 'guidance.json')):
-            optimizer.importGuidanceJSON(os.path.join(args.results_directory, 'guidance.json'))
+        results_path = os.path.join(args.results_directory, 'results.csv')
+        if os.path.exists(results_path):
+            optimizer.importResultsCSV(results_path)
+
+        guidance_path = os.path.join(args.results_directory, 'guidance.json')
+        if os.path.exists(guidance_path):
+            optimizer.importGuidanceJSON(guidance_path)
+
         optimizer.resultsAnalyzer.directory = args.results_directory
     else:
         # See if we see the results directory here.


### PR DESCRIPTION
Hi! I've been trying to use HyperMax in Windows and found a couple of issues. Hence, you'll see a few PRs from me hoping to help make this product a little better.

----

In this case, hypermax would crash because it would try to read `results.csv`, and it was not handling the case where the file did not exist (like on a first run).

Solution is to just check for the file existence before calling `optimizer.importResultsCSV()`.